### PR TITLE
Add ign tools metadata to -dev install file

### DIFF
--- a/ubuntu/debian/libignition-plugin-dev.install
+++ b/ubuntu/debian/libignition-plugin-dev.install
@@ -2,4 +2,6 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/ignition-plugin*/*
+usr/lib/ruby/ignition/*
+usr/share/ignition/*
 usr/share/ignition/*/*


### PR DESCRIPTION
Ported from https://github.com/ignition-release/ign-plugin2-release/pull/1 that fixed unstable nightly debbuilds.