### PR TITLE
Install bash completion scripts and move gz tool scripts to non-dev package

### DIFF
--- a/ubuntu/debian/libignition-plugin-dev.install
+++ b/ubuntu/debian/libignition-plugin-dev.install
@@ -2,6 +2,4 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/ignition-plugin*/*
-usr/lib/ruby/ignition/*
-usr/share/ignition/*
 usr/share/ignition/*/*

--- a/ubuntu/debian/libignition-plugin.install
+++ b/ubuntu/debian/libignition-plugin.install
@@ -1,1 +1,4 @@
 usr/lib/*/*.so.*
+usr/lib/ruby/ignition/*
+usr/share/ignition/*.yaml
+usr/share/gz/*


### PR DESCRIPTION
Installs bash completion scripts to `usr/share/gz`. Also moves gz-tool scripts to non-dev deb packages (Toward https://github.com/gazebo-tooling/release-tools/issues/529)